### PR TITLE
Added ability to omit merge commits

### DIFF
--- a/src/providers/changelog/file.ts
+++ b/src/providers/changelog/file.ts
@@ -126,8 +126,10 @@ const Changelog = {
       if ( Config.changelog.commit ) {
 
         commits.reverse ().forEach ( commit => {
-
+          
           if ( commit.isBump ) return;
+          
+          if (commit.message.toLowerCase().includes('merge')) return;
 
           const {hash, date, message, author_name, author_email} = commit,
                 messageCleaned = message.replace ( / \(HEAD\)$/i, '' ).replace ( / \(HEAD -> [^)]+\)$/i, '' ).replace ( / \(tag: [^)]+\)$/i, '' )


### PR DESCRIPTION
Hi @fabiospampinato  firstly I would like to say that I liked ``bump`` so much and already added to a couple of projects, thanks for the module. When we are implementing this for a changelog we thought it would be so good if there is an option to omit ``Merge`` commits into the changelog. So, I just made a few changes and giving a PR, would like to know your inputs on this 😄 