### PR TITLE
Patch moment CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mime-types": "^2.1.21",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "moment": "2.4.0",
+    "moment": "^2.19.3",
     "opn": "^5.4.0",
     "pify": "^3.0.0",
     "read-pkg-up": "^2.0.0",

--- a/src/providers/changelog/file.ts
+++ b/src/providers/changelog/file.ts
@@ -138,7 +138,7 @@ const Changelog = {
                 messageCleaned = message.replace ( / \(HEAD\)$/i, '' ).replace ( / \(HEAD -> [^)]+\)$/i, '' ).replace ( / \(tag: [^)]+\)$/i, '' )
 
           const commitTokens = _.extend ( {}, tokens, {
-            date: moment ( date ).format ( Config.tokens.date.format ),
+            date: moment ( new Date ( date ) ).format ( Config.tokens.date.format ),
             message: messageCleaned,
             hash,
             hash4: hash.slice ( 0, 4 ),


### PR DESCRIPTION
Been using this package in some of my projects. However a recent push to one of them caused a bunch of GitHub security alerts to pop up. Specifically [CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214) and [CVE-2016-4055](https://nvd.nist.gov/vuln/detail/CVE-2016-4055) which have been patched in Moment v2.19.3, but the version here was locked to 2.4.0 for whatever reason.

I've bumped this version up to at least 2.19.3 which patches these vulns. I've also included a fix for a deprecation caused by this newer version of moment.